### PR TITLE
fix(mac): fix ladybug_tools folder path on Mac

### DIFF
--- a/src/HoneybeeSchema.Test/Model/ModelEnergyPropertiesTests.cs
+++ b/src/HoneybeeSchema.Test/Model/ModelEnergyPropertiesTests.cs
@@ -46,6 +46,16 @@ namespace HoneybeeSchema.Test
                 instance = ModelEnergyProperties.FromJson(json);
             }
 
+            if (System.Environment.OSVersion.Platform == PlatformID.Unix)
+            {
+                //var homeDir = Environment.GetEnvironmentVariable("HOME");
+                ////var dirs = Directory.GetDirectories("$HOME");
+                //var json = Path.Combine(homeDir, "ladybug_tools", "resources/standards/default/defaultModelEnergyProperty.json");
+                //var isfile = File.Exists(json);
+
+                instance = Helper.EnergyLibrary.DefaultModelEnergyProperties;
+            }
+                
 
         }
 

--- a/src/HoneybeeSchema.Test/Model/VoidTests.cs
+++ b/src/HoneybeeSchema.Test/Model/VoidTests.cs
@@ -41,9 +41,12 @@ namespace HoneybeeSchema.Test
         [SetUp]
         public void Init()
         {
+            
             var dir = Path.GetDirectoryName(this.GetType().Assembly.Location);
             Directory.SetCurrentDirectory(dir);
             var file = @"..\..\..\..\samples\modifier\void.json";
+            if (System.Environment.OSVersion.Platform == PlatformID.Unix)
+                file = @"../../../../samples/modifier/void.json";
             using (StreamReader sr = File.OpenText(file))
             {
                 string s = sr.ReadToEnd();

--- a/src/HoneybeeSchema/Helper/EnergyLibrary.cs
+++ b/src/HoneybeeSchema/Helper/EnergyLibrary.cs
@@ -558,6 +558,18 @@ namespace HoneybeeSchema.Helper
 
         private static string GetLadybugToolsInstallationPath()
         {
+            // Mac
+            if (System.Environment.OSVersion.Platform == PlatformID.Unix)
+            {
+                var homeDir = Environment.GetEnvironmentVariable("HOME");
+                var dir = Path.Combine(homeDir, "ladybug_tools");
+
+                if( Directory.Exists(dir)) return dir;
+                throw new ArgumentException($"Ladybug Tools is not installed in this Mac's {homeDir}!");
+
+            }
+
+            // windows
             var scr = $"/C REG QUERY HKEY_CURRENT_USER\\SOFTWARE\\MICROSOFT\\WINDOWS\\CURRENTVERSION\\UNINSTALL /s /v InstallLocation | findstr \"ladybug_tools\"";
     
             var startInfo = new System.Diagnostics.ProcessStartInfo();


### PR DESCRIPTION
On mac, it has to be installed in $HOME/ladybug_tools